### PR TITLE
Use VS2022 in CI

### DIFF
--- a/.github/workflows/macos-linux-windows-pixi.yml
+++ b/.github/workflows/macos-linux-windows-pixi.yml
@@ -45,11 +45,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-15-intel, windows-latest]
+        os: [ubuntu-latest, macos-latest, macos-15-intel, windows-2022]
         environment: [all, all-python-oldest, eigen3-all, eigen3-python-oldest]
         build_type: [Release, Debug]
         include:
-          - os: windows-latest
+          - os: windows-2022
             environment: all-clang-cl
             build_type: Release
 
@@ -98,7 +98,7 @@ jobs:
   #   strategy:
   #     fail-fast: false
   #     matrix:
-  #       os: [ubuntu-latest, macos-latest, macos-15-intel, windows-latest]
+  #       os: [ubuntu-latest, macos-latest, macos-15-intel, windows-2022]
 
   #   steps:
   #   - uses: actions/checkout@v6


### PR DESCRIPTION
- Github migrate windows-latest to windows image using vs2026. Right now, it's not the default compiler used by conda and workflow will fail.